### PR TITLE
chore: restore Rust quality baseline

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -27,7 +27,7 @@ impl Browser {
 
         let mut args_str = vec![
             "--no-sandbox",
-            "--disable-gpu", 
+            "--disable-gpu",
             "--disable-dev-shm-usage",
             "--disable-setuid-sandbox",
             "--no-first-run",
@@ -51,7 +51,7 @@ impl Browser {
 
         let args_os: Vec<std::ffi::OsString> = args_str.iter().map(|s| (*s).into()).collect();
         let args_refs: Vec<&std::ffi::OsStr> = args_os.iter().map(|s| s.as_os_str()).collect();
-        
+
         let launch_options = if let Some(path) = chrome_path {
             LaunchOptions::default_builder()
                 .headless(true)
@@ -89,7 +89,9 @@ impl Browser {
     ) -> Result<()> {
         options.validate()?;
 
-        let tab = self.browser.new_tab()
+        let tab = self
+            .browser
+            .new_tab()
             .map_err(|e| WebshotError::Tab(e.to_string()))?;
         self.setup_tab(&tab, options).await?;
 
@@ -115,7 +117,8 @@ impl Browser {
         // Wait for specific element if requested
         if let Some(selector) = &options.wait_for {
             info!("Waiting for element: {}", selector);
-            self.wait_for_element(&tab, selector, options.timeout).await?;
+            self.wait_for_element(&tab, selector, options.timeout)
+                .await?;
         }
 
         // Additional wait time
@@ -143,6 +146,7 @@ impl Browser {
     }
 
     /// Generate a PDF from a webpage
+    #[allow(clippy::too_many_arguments)]
     pub async fn pdf<P: AsRef<Path>>(
         &self,
         url: &str,
@@ -156,13 +160,15 @@ impl Browser {
         timeout: u64,
         user_agent: Option<String>,
     ) -> Result<()> {
-        let tab = self.browser.new_tab()
+        let tab = self
+            .browser
+            .new_tab()
             .map_err(|e| WebshotError::Tab(e.to_string()))?;
 
         // Set up the tab
         if let Some(user_agent) = user_agent {
             tab.set_user_agent(&user_agent, None, None)
-                .map_err(|e| WebshotError::Browser(e.into()))?;
+                .map_err(WebshotError::Browser)?;
         }
 
         info!("Navigating to: {}", url);
@@ -175,7 +181,7 @@ impl Browser {
         if let Some(script) = &javascript {
             if self.javascript_enabled {
                 info!("Executing JavaScript: {}", script);
-                tab.evaluate(&script, false)
+                tab.evaluate(script, false)
                     .map_err(|e| WebshotError::javascript(e.to_string()))?;
             } else {
                 warn!("JavaScript disabled, skipping script execution");
@@ -211,7 +217,8 @@ impl Browser {
             generate_tagged_pdf: Some(false),
         };
 
-        let pdf_data = tab.print_to_pdf(Some(pdf_options))
+        let pdf_data = tab
+            .print_to_pdf(Some(pdf_options))
             .map_err(|e| WebshotError::pdf(e.to_string()))?;
         std::fs::write(&output_path, pdf_data)?;
 
@@ -229,13 +236,15 @@ impl Browser {
         timeout: u64,
         user_agent: Option<String>,
     ) -> Result<String> {
-        let tab = self.browser.new_tab()
+        let tab = self
+            .browser
+            .new_tab()
             .map_err(|e| WebshotError::Tab(e.to_string()))?;
 
         // Set up the tab
         if let Some(user_agent) = user_agent {
             tab.set_user_agent(&user_agent, None, None)
-                .map_err(|e| WebshotError::Browser(e.into()))?;
+                .map_err(WebshotError::Browser)?;
         }
 
         info!("Navigating to: {}", url);
@@ -248,7 +257,7 @@ impl Browser {
         if let Some(script) = &javascript {
             if self.javascript_enabled {
                 info!("Executing JavaScript: {}", script);
-                tab.evaluate(&script, false)
+                tab.evaluate(script, false)
                     .map_err(|e| WebshotError::javascript(e.to_string()))?;
             } else {
                 warn!("JavaScript disabled, skipping script execution");
@@ -263,16 +272,15 @@ impl Browser {
 
         let text = if let Some(selector_str) = selector {
             info!("Extracting text from element: {}", selector_str);
-            let element = tab.find_element(&selector_str)
-                .map_err(|_e| WebshotError::ElementNotFound {
-                    selector: selector_str,
-                })?;
-            element.get_inner_text()
-                .map_err(|e| WebshotError::Browser(e.into()))?
+            let element =
+                tab.find_element(&selector_str)
+                    .map_err(|_e| WebshotError::ElementNotFound {
+                        selector: selector_str,
+                    })?;
+            element.get_inner_text().map_err(WebshotError::Browser)?
         } else {
             info!("Extracting text from entire page");
-            tab.get_content()
-                .map_err(|e| WebshotError::Browser(e.into()))?
+            tab.get_content().map_err(WebshotError::Browser)?
         };
 
         Ok(text)
@@ -309,7 +317,10 @@ impl Browser {
             }
         });
 
-        let results: Vec<Result<()>> = stream::iter(tasks).buffer_unordered(parallel).collect().await;
+        let results: Vec<Result<()>> = stream::iter(tasks)
+            .buffer_unordered(parallel)
+            .collect()
+            .await;
 
         // Check for errors
         for (i, result) in results.into_iter().enumerate() {
@@ -325,27 +336,30 @@ impl Browser {
         // Set viewport using emulation
         tab.set_default_timeout(std::time::Duration::from_secs(options.timeout));
 
-        tab.call_method(headless_chrome::protocol::cdp::Emulation::SetDeviceMetricsOverride {
-            width: options.width,
-            height: options.height,
-            device_scale_factor: options.device_scale_factor(),
-            mobile: false,
-            scale: None,
-            screen_width: None,
-            screen_height: None,
-            position_x: None,
-            position_y: None,
-            dont_set_visible_size: None,
-            screen_orientation: None,
-            viewport: None,
-            display_feature: None,
-            device_posture: None,
-        }).map_err(|e| WebshotError::Browser(e.into()))?;
+        tab.call_method(
+            headless_chrome::protocol::cdp::Emulation::SetDeviceMetricsOverride {
+                width: options.width,
+                height: options.height,
+                device_scale_factor: options.device_scale_factor(),
+                mobile: false,
+                scale: None,
+                screen_width: None,
+                screen_height: None,
+                position_x: None,
+                position_y: None,
+                dont_set_visible_size: None,
+                screen_orientation: None,
+                viewport: None,
+                display_feature: None,
+                device_posture: None,
+            },
+        )
+        .map_err(WebshotError::Browser)?;
 
         // Set user agent if provided
         if let Some(user_agent) = &options.user_agent {
             tab.set_user_agent(user_agent, None, None)
-                .map_err(|e| WebshotError::Browser(e.into()))?;
+                .map_err(WebshotError::Browser)?;
         }
 
         Ok(())
@@ -381,21 +395,18 @@ impl Browser {
     ) -> Result<()> {
         let screenshot_data = if let Some(selector) = &options.selector {
             info!("Taking element screenshot: {}", selector);
-            let element = tab
-                .find_element(selector)
-                .map_err(|_e| WebshotError::ElementNotFound {
-                    selector: selector.clone(),
-                })?;
-            element.capture_screenshot(Page::CaptureScreenshotFormatOption::Png)
+            let element =
+                tab.find_element(selector)
+                    .map_err(|_e| WebshotError::ElementNotFound {
+                        selector: selector.clone(),
+                    })?;
+            element
+                .capture_screenshot(Page::CaptureScreenshotFormatOption::Png)
                 .map_err(|e| WebshotError::screenshot(e.to_string()))?
         } else {
             info!("Taking full page screenshot");
-            tab.capture_screenshot(
-                Page::CaptureScreenshotFormatOption::Png,
-                None,
-                None,
-                true,
-            ).map_err(|e| WebshotError::screenshot(e.to_string()))?
+            tab.capture_screenshot(Page::CaptureScreenshotFormatOption::Png, None, None, true)
+                .map_err(|e| WebshotError::screenshot(e.to_string()))?
         };
 
         match format {
@@ -407,15 +418,16 @@ impl Browser {
                 let img = image::load_from_memory(&screenshot_data)?;
                 let mut output = std::fs::File::create(&output_path)?;
                 let quality = options.quality.unwrap_or(90);
-                
-                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut output, quality);
+
+                let encoder =
+                    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut output, quality);
                 img.write_with_encoder(encoder)?;
             }
             ImageFormat::WebP => {
                 // Convert PNG to WebP
                 let img = image::load_from_memory(&screenshot_data)?;
                 let mut output = std::fs::File::create(&output_path)?;
-                
+
                 let encoder = image::codecs::webp::WebPEncoder::new_lossless(&mut output);
                 img.write_with_encoder(encoder)?;
             }
@@ -434,7 +446,9 @@ impl Browser {
         config: ScreenshotConfig,
         output_dir: Option<PathBuf>,
     ) -> Result<()> {
-        let tab = self.browser.new_tab()
+        let tab = self
+            .browser
+            .new_tab()
             .map_err(|e| WebshotError::Tab(e.to_string()))?;
 
         // Determine output path
@@ -485,7 +499,7 @@ impl Browser {
                 partition_key: None,
             };
             tab.set_cookies(vec![cookie_param])
-                .map_err(|e| WebshotError::Browser(e.into()))?;
+                .map_err(WebshotError::Browser)?;
         }
 
         // Set custom headers
@@ -496,13 +510,13 @@ impl Browser {
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
             tab.set_extra_http_headers(headers)
-                .map_err(|e| WebshotError::Browser(e.into()))?;
+                .map_err(WebshotError::Browser)?;
         }
 
         // Handle authentication
         if let Some(auth) = &config.auth {
             tab.authenticate(Some(auth.username.clone()), Some(auth.password.clone()))
-                .map_err(|e| WebshotError::Browser(e.into()))?;
+                .map_err(WebshotError::Browser)?;
         }
 
         // Navigate and process
@@ -521,7 +535,8 @@ impl Browser {
 
         // Wait for element
         if let Some(selector) = &config.wait_for {
-            self.wait_for_element(&tab, selector, config.timeout).await?;
+            self.wait_for_element(&tab, selector, config.timeout)
+                .await?;
         }
 
         // Wait before screenshot
@@ -554,7 +569,8 @@ impl Browser {
                     generate_tagged_pdf: Some(false),
                 };
 
-                let pdf_data = tab.print_to_pdf(Some(pdf_options))
+                let pdf_data = tab
+                    .print_to_pdf(Some(pdf_options))
                     .map_err(|e| WebshotError::pdf(e.to_string()))?;
                 std::fs::write(&output_path, pdf_data)?;
             }

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -5,9 +5,10 @@ use std::path::Path;
 use tracing::{debug, info};
 
 /// Image comparison algorithms
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ComparisonAlgorithm {
     /// Pixel-by-pixel difference
+    #[default]
     PixelDiff,
     /// Structural Similarity Index (SSIM)
     SSIM,
@@ -15,12 +16,6 @@ pub enum ComparisonAlgorithm {
     MSE,
     /// Peak Signal-to-Noise Ratio
     PSNR,
-}
-
-impl Default for ComparisonAlgorithm {
-    fn default() -> Self {
-        Self::PixelDiff
-    }
 }
 
 /// Comparison options
@@ -87,7 +82,7 @@ impl ImageComparator {
             .map_err(|e| WebshotError::config(format!("Failed to load first image: {}", e)))?;
         let image2 = image::open(&image2_path)
             .map_err(|e| WebshotError::config(format!("Failed to load second image: {}", e)))?;
-        
+
         Self::compare_images(&image1, &image2, options)
     }
 
@@ -113,7 +108,7 @@ impl ImageComparator {
         let total_pixels = width * height;
 
         info!("Comparing images using {:?} algorithm", options.algorithm);
-        
+
         let (similarity, different_pixels) = match options.algorithm {
             ComparisonAlgorithm::PixelDiff => Self::pixel_diff_comparison(&img1, &img2, options),
             ComparisonAlgorithm::SSIM => (Self::ssim_comparison(&img1, &img2)?, None),
@@ -167,8 +162,11 @@ impl ImageComparator {
 
         let total_pixels = width * height;
         let similarity = 1.0 - (different_pixels as f64 / total_pixels as f64);
-        
-        debug!("Pixel diff: {}/{} different pixels", different_pixels, total_pixels);
+
+        debug!(
+            "Pixel diff: {}/{} different pixels",
+            different_pixels, total_pixels
+        );
         (similarity, Some(different_pixels))
     }
 
@@ -183,7 +181,7 @@ impl ImageComparator {
         let r_diff = (pixel1[0] as i16 - pixel2[0] as i16).abs();
         let g_diff = (pixel1[1] as i16 - pixel2[1] as i16).abs();
         let b_diff = (pixel1[2] as i16 - pixel2[2] as i16).abs();
-        
+
         r_diff <= threshold && g_diff <= threshold && b_diff <= threshold
     }
 
@@ -192,7 +190,7 @@ impl ImageComparator {
         // Convert to grayscale for SSIM calculation
         let gray1 = Self::rgb_to_grayscale(img1);
         let gray2 = Self::rgb_to_grayscale(img2);
-        
+
         let ssim = Self::calculate_ssim(&gray1, &gray2)?;
         Ok(ssim)
     }
@@ -215,7 +213,7 @@ impl ImageComparator {
         }
 
         mse /= (width * height * 3) as f64;
-        
+
         // Convert MSE to similarity (lower MSE = higher similarity)
         1.0 / (1.0 + mse / 255.0)
     }
@@ -246,7 +244,7 @@ impl ImageComparator {
         }
 
         let psnr = 20.0 * (255.0_f64).log10() - 10.0 * mse.log10();
-        
+
         // Convert PSNR to similarity (higher PSNR = higher similarity)
         // Typical PSNR values: 30-50 dB is good, >50 dB is very good
         // Normalize PSNR to 0-1 range, where 30dB = 0.3, 50dB = 0.5, etc.
@@ -265,8 +263,8 @@ impl ImageComparator {
         for y in 0..height {
             for x in 0..width {
                 let pixel = img.get_pixel(x, y);
-                let gray_value = (0.299 * pixel[0] as f64 
-                    + 0.587 * pixel[1] as f64 
+                let gray_value = (0.299 * pixel[0] as f64
+                    + 0.587 * pixel[1] as f64
                     + 0.114 * pixel[2] as f64) as u8;
                 gray.put_pixel(x, y, image::Luma([gray_value]));
             }
@@ -281,7 +279,7 @@ impl ImageComparator {
         img2: &ImageBuffer<image::Luma<u8>, Vec<u8>>,
     ) -> Result<f64> {
         let (width, height) = img1.dimensions();
-        
+
         // Constants for SSIM calculation
         let k1 = 0.01_f64;
         let k2 = 0.03_f64;
@@ -313,10 +311,10 @@ impl ImageComparator {
             for x in 0..width {
                 let val1 = img1.get_pixel(x, y)[0] as f64;
                 let val2 = img2.get_pixel(x, y)[0] as f64;
-                
+
                 let diff1 = val1 - mean1;
                 let diff2 = val2 - mean2;
-                
+
                 var1 += diff1 * diff1;
                 var2 += diff2 * diff2;
                 covar += diff1 * diff2;
@@ -330,9 +328,9 @@ impl ImageComparator {
         // Calculate SSIM
         let numerator = (2.0 * mean1 * mean2 + c1) * (2.0 * covar + c2);
         let denominator = (mean1 * mean1 + mean2 * mean2 + c1) * (var1 + var2 + c2);
-        
+
         let ssim = numerator / denominator;
-        Ok(ssim.max(0.0).min(1.0))
+        Ok(ssim.clamp(0.0, 1.0))
     }
 
     /// Generate a difference image highlighting changes
@@ -355,19 +353,27 @@ impl ImageComparator {
                     diff_img.put_pixel(x, y, *pixel1);
                 } else {
                     // Highlight difference
-                    diff_img.put_pixel(x, y, Rgb([
-                        options.diff_color.0,
-                        options.diff_color.1,
-                        options.diff_color.2,
-                    ]));
+                    diff_img.put_pixel(
+                        x,
+                        y,
+                        Rgb([
+                            options.diff_color.0,
+                            options.diff_color.1,
+                            options.diff_color.2,
+                        ]),
+                    );
                 }
             }
         }
 
-        diff_img.save(&output_path)
+        diff_img
+            .save(&output_path)
             .map_err(|e| WebshotError::config(format!("Failed to save diff image: {}", e)))?;
 
-        info!("Difference image saved to: {}", output_path.as_ref().display());
+        info!(
+            "Difference image saved to: {}",
+            output_path.as_ref().display()
+        );
         Ok(())
     }
 }
@@ -442,10 +448,10 @@ mod tests {
     fn test_identical_images() {
         let img1 = create_test_image(100, 100, [255, 0, 0]);
         let img2 = create_test_image(100, 100, [255, 0, 0]);
-        
+
         let options = ComparisonOptions::new();
         let result = ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
-        
+
         assert!(result.similar);
         assert_eq!(result.similarity, 1.0);
         assert_eq!(result.different_pixels, Some(0));
@@ -455,10 +461,10 @@ mod tests {
     fn test_different_images() {
         let img1 = create_test_image(100, 100, [255, 0, 0]);
         let img2 = create_test_image(100, 100, [0, 255, 0]);
-        
+
         let options = ComparisonOptions::new();
         let result = ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
-        
+
         assert!(!result.similar);
         assert_eq!(result.similarity, 0.0);
         assert_eq!(result.different_pixels, Some(10000));
@@ -468,10 +474,10 @@ mod tests {
     fn test_dimension_mismatch() {
         let img1 = create_test_image(100, 100, [255, 0, 0]);
         let img2 = create_test_image(200, 100, [255, 0, 0]);
-        
+
         let options = ComparisonOptions::new();
         let result = ImageComparator::compare_images(&img1.into(), &img2.into(), &options);
-        
+
         assert!(result.is_err());
     }
 
@@ -479,15 +485,14 @@ mod tests {
     fn test_diff_image_generation() {
         let temp_dir = TempDir::new().unwrap();
         let diff_path = temp_dir.path().join("diff.png");
-        
+
         let img1 = create_test_image(10, 10, [255, 0, 0]);
         let img2 = create_test_image(10, 10, [0, 255, 0]);
-        
-        let options = ComparisonOptions::new()
-            .generate_diff_image(&diff_path);
-        
+
+        let options = ComparisonOptions::new().generate_diff_image(&diff_path);
+
         let result = ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
-        
+
         assert!(diff_path.exists());
         assert_eq!(result.diff_image_path, Some(diff_path));
     }
@@ -503,15 +508,21 @@ mod tests {
         ] {
             let img1 = create_test_image(50, 50, [255, 0, 0]);
             let img2 = create_test_image(50, 50, [255, 0, 0]); // Identical
-            
+
             let options = ComparisonOptions::new().algorithm(algorithm);
-            let result = ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
-            
+            let result =
+                ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
+
             // Identical images should have high similarity
-            assert!(result.similarity >= 0.9, "Algorithm {:?} didn't recognize identical images: {}", algorithm, result.similarity);
+            assert!(
+                result.similarity >= 0.9,
+                "Algorithm {:?} didn't recognize identical images: {}",
+                algorithm,
+                result.similarity
+            );
             assert_eq!(result.algorithm, algorithm);
         }
-        
+
         // Test with completely different images
         for algorithm in [
             ComparisonAlgorithm::PixelDiff,
@@ -521,15 +532,30 @@ mod tests {
         ] {
             let img1 = create_test_image(50, 50, [255, 0, 0]); // Red
             let img2 = create_test_image(50, 50, [0, 255, 0]); // Green - completely different
-            
+
             let options = ComparisonOptions::new().algorithm(algorithm);
-            let result = ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
-            
+            let result =
+                ImageComparator::compare_images(&img1.into(), &img2.into(), &options).unwrap();
+
             // Completely different images should have low similarity
             // SSIM measures structural similarity, so solid colors might still be similar
-            let max_similarity = if algorithm == ComparisonAlgorithm::SSIM { 0.9 } else { 0.5 };
-            assert!(result.similarity <= max_similarity, "Algorithm {:?} gave too high similarity for different images: {}", algorithm, result.similarity);
-            assert!(result.similarity >= 0.0, "Algorithm {:?} returned negative similarity: {}", algorithm, result.similarity);
+            let max_similarity = if algorithm == ComparisonAlgorithm::SSIM {
+                0.9
+            } else {
+                0.5
+            };
+            assert!(
+                result.similarity <= max_similarity,
+                "Algorithm {:?} gave too high similarity for different images: {}",
+                algorithm,
+                result.similarity
+            );
+            assert!(
+                result.similarity >= 0.0,
+                "Algorithm {:?} returned negative similarity: {}",
+                algorithm,
+                result.similarity
+            );
             assert_eq!(result.algorithm, algorithm);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,7 +163,9 @@ impl Config {
             if screenshot.height == default_height() && config.defaults.height != default_height() {
                 screenshot.height = config.defaults.height;
             }
-            if screenshot.timeout == default_timeout() && config.defaults.timeout != default_timeout() {
+            if screenshot.timeout == default_timeout()
+                && config.defaults.timeout != default_timeout()
+            {
                 screenshot.timeout = config.defaults.timeout;
             }
             if screenshot.user_agent.is_none() && config.defaults.user_agent.is_some() {
@@ -172,12 +174,15 @@ impl Config {
             if screenshot.quality.is_none() && config.defaults.quality.is_some() {
                 screenshot.quality = config.defaults.quality;
             }
-            
+
             // Merge headers
             for (key, value) in &config.defaults.headers {
-                screenshot.headers.entry(key.clone()).or_insert_with(|| value.clone());
+                screenshot
+                    .headers
+                    .entry(key.clone())
+                    .or_insert_with(|| value.clone());
             }
-            
+
             // Merge cookies
             if screenshot.cookies.is_empty() && !config.defaults.cookies.is_empty() {
                 screenshot.cookies = config.defaults.cookies.clone();
@@ -204,13 +209,16 @@ impl Config {
     /// Validate the configuration
     pub fn validate(&self) -> Result<()> {
         if self.screenshots.is_empty() {
-            return Err(WebshotError::config("No screenshots defined in configuration"));
+            return Err(WebshotError::config(
+                "No screenshots defined in configuration",
+            ));
         }
 
         for (i, screenshot) in self.screenshots.iter().enumerate() {
             // Validate URL
-            url::Url::parse(&screenshot.url)
-                .map_err(|e| WebshotError::config(format!("Invalid URL in screenshot {}: {}", i, e)))?;
+            url::Url::parse(&screenshot.url).map_err(|e| {
+                WebshotError::config(format!("Invalid URL in screenshot {}: {}", i, e))
+            })?;
 
             // Validate viewport dimensions
             if screenshot.width == 0 || screenshot.height == 0 {
@@ -294,7 +302,6 @@ fn default_diff_color() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
 
     #[test]
     fn test_config_serialization() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use webshot::{Browser, Config, Result, ScreenshotOptions, ComparisonOptions, ImageComparator};
+use webshot::{Browser, ComparisonOptions, Config, ImageComparator, Result, ScreenshotOptions};
 
 #[derive(Parser)]
 #[command(
@@ -242,8 +242,21 @@ async fn main() -> Result<()> {
             wait,
         }) => {
             take_screenshot(
-                &url, output, width, height, selector, javascript, wait_for, timeout, retina,
-                quality, wait, chrome_path, chrome_flags, no_javascript, user_agent,
+                &url,
+                output,
+                width,
+                height,
+                selector,
+                javascript,
+                wait_for,
+                timeout,
+                retina,
+                quality,
+                wait,
+                chrome_path,
+                chrome_flags,
+                no_javascript,
+                user_agent,
             )
             .await
         }
@@ -259,8 +272,19 @@ async fn main() -> Result<()> {
             timeout,
         }) => {
             generate_pdf(
-                &url, output, &format, landscape, background, scale, javascript, wait_for,
-                timeout, chrome_path, chrome_flags, no_javascript, user_agent,
+                &url,
+                output,
+                &format,
+                landscape,
+                background,
+                scale,
+                javascript,
+                wait_for,
+                timeout,
+                chrome_path,
+                chrome_flags,
+                no_javascript,
+                user_agent,
             )
             .await
         }
@@ -268,7 +292,17 @@ async fn main() -> Result<()> {
             config_file,
             output_dir,
             parallel,
-        }) => process_config(&config_file, output_dir, parallel, chrome_path, chrome_flags, no_javascript).await,
+        }) => {
+            process_config(
+                &config_file,
+                output_dir,
+                parallel,
+                chrome_path,
+                chrome_flags,
+                no_javascript,
+            )
+            .await
+        }
         Some(Commands::Text {
             url,
             selector,
@@ -277,7 +311,19 @@ async fn main() -> Result<()> {
             wait_for,
             timeout,
         }) => {
-            extract_text(&url, selector, output, javascript, wait_for, timeout, chrome_path, chrome_flags, no_javascript, user_agent).await
+            extract_text(
+                &url,
+                selector,
+                output,
+                javascript,
+                wait_for,
+                timeout,
+                chrome_path,
+                chrome_flags,
+                no_javascript,
+                user_agent,
+            )
+            .await
         }
         Some(Commands::Compare {
             image1,
@@ -292,9 +338,18 @@ async fn main() -> Result<()> {
             format,
         }) => {
             compare_images(
-                &image1, &image2, output, &algorithm, threshold, diff_image, diff_path,
-                ignore_antialiasing, &diff_color, &format,
-            ).await
+                &image1,
+                &image2,
+                output,
+                &algorithm,
+                threshold,
+                diff_image,
+                diff_path,
+                ignore_antialiasing,
+                &diff_color,
+                &format,
+            )
+            .await
         }
         None => {
             // Default behavior: screenshot with URL as positional argument
@@ -343,6 +398,7 @@ fn init_logging(verbose: u8) {
         .init();
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn take_screenshot(
     url: &str,
     output: Option<PathBuf>,
@@ -362,12 +418,7 @@ async fn take_screenshot(
 ) -> Result<()> {
     info!("Taking screenshot of: {}", url);
 
-    let browser = Browser::new(
-        chrome_path,
-        chrome_flags,
-        !no_javascript,
-    )
-    .await?;
+    let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;
 
     let options = ScreenshotOptions {
         width,
@@ -382,7 +433,7 @@ async fn take_screenshot(
         user_agent,
     };
 
-    let output_path = output.as_ref().map(|p| p.clone()).unwrap_or_else(|| {
+    let output_path = output.clone().unwrap_or_else(|| {
         // Determine format from output path or default to PNG
         let format = if let Some(ref output_path) = output {
             if let Some(ext) = output_path.extension() {
@@ -398,7 +449,7 @@ async fn take_screenshot(
         } else {
             "png"
         };
-        
+
         PathBuf::from(format!(
             "screenshot_{}.{}",
             chrono::Utc::now().format("%Y%m%d_%H%M%S"),
@@ -412,6 +463,7 @@ async fn take_screenshot(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn generate_pdf(
     url: &str,
     output: Option<PathBuf>,
@@ -429,12 +481,7 @@ async fn generate_pdf(
 ) -> Result<()> {
     info!("Generating PDF of: {}", url);
 
-    let browser = Browser::new(
-        chrome_path,
-        chrome_flags,
-        !no_javascript,
-    )
-    .await?;
+    let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;
 
     let output_path = output.unwrap_or_else(|| {
         PathBuf::from(format!(
@@ -473,19 +520,17 @@ async fn process_config(
     info!("Processing config file: {}", config_file.display());
 
     let config = Config::from_file(config_file)?;
-    let browser = Browser::new(
-        chrome_path,
-        chrome_flags,
-        !no_javascript,
-    )
-    .await?;
+    let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;
 
-    browser.process_config(&config, output_dir, parallel).await?;
+    browser
+        .process_config(&config, output_dir, parallel)
+        .await?;
 
     println!("Batch processing completed successfully");
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn extract_text(
     url: &str,
     selector: Option<String>,
@@ -500,12 +545,7 @@ async fn extract_text(
 ) -> Result<()> {
     info!("Extracting text from: {}", url);
 
-    let browser = Browser::new(
-        chrome_path,
-        chrome_flags,
-        !no_javascript,
-    )
-    .await?;
+    let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;
 
     let text = browser
         .extract_text(url, selector, javascript, wait_for, timeout, user_agent)
@@ -525,6 +565,7 @@ async fn extract_text(
 }
 
 /// Compare two images and output results
+#[allow(clippy::too_many_arguments)]
 async fn compare_images(
     image1_path: &std::path::Path,
     image2_path: &std::path::Path,
@@ -537,7 +578,7 @@ async fn compare_images(
     diff_color: &str,
     output_format: &str,
 ) -> Result<()> {
-    use webshot::comparison::{ComparisonAlgorithm};
+    use webshot::comparison::ComparisonAlgorithm;
 
     // Parse algorithm
     let algorithm = match algorithm.to_lowercase().as_str() {
@@ -545,9 +586,12 @@ async fn compare_images(
         "ssim" => ComparisonAlgorithm::SSIM,
         "mse" => ComparisonAlgorithm::MSE,
         "psnr" => ComparisonAlgorithm::PSNR,
-        _ => return Err(webshot::WebshotError::config(format!(
-            "Unknown algorithm: {}. Supported: pixel-diff, ssim, mse, psnr", algorithm
-        ))),
+        _ => {
+            return Err(webshot::WebshotError::config(format!(
+                "Unknown algorithm: {}. Supported: pixel-diff, ssim, mse, psnr",
+                algorithm
+            )))
+        }
     };
 
     // Parse diff color
@@ -578,17 +622,22 @@ async fn compare_images(
 
     options.validate()?;
 
-    info!("Comparing images: {} vs {}", image1_path.display(), image2_path.display());
-    
+    info!(
+        "Comparing images: {} vs {}",
+        image1_path.display(),
+        image2_path.display()
+    );
+
     // Perform comparison
     let result = ImageComparator::compare_files(image1_path, image2_path, &options)?;
 
     // Output results
     match output_format.to_lowercase().as_str() {
         "json" => {
-            let json = serde_json::to_string_pretty(&result)
-                .map_err(|e| webshot::WebshotError::config(format!("JSON serialization failed: {}", e)))?;
-            
+            let json = serde_json::to_string_pretty(&result).map_err(|e| {
+                webshot::WebshotError::config(format!("JSON serialization failed: {}", e))
+            })?;
+
             if let Some(output_path) = output {
                 std::fs::write(output_path, json)?;
                 info!("Comparison results saved to JSON file");
@@ -598,7 +647,7 @@ async fn compare_images(
         }
         "text" => {
             let text_output = format_comparison_result(&result);
-            
+
             if let Some(output_path) = output {
                 std::fs::write(output_path, text_output)?;
                 info!("Comparison results saved to text file");
@@ -606,17 +655,26 @@ async fn compare_images(
                 println!("{}", text_output);
             }
         }
-        _ => return Err(webshot::WebshotError::config(format!(
-            "Unknown output format: {}. Supported: json, text", output_format
-        ))),
+        _ => {
+            return Err(webshot::WebshotError::config(format!(
+                "Unknown output format: {}. Supported: json, text",
+                output_format
+            )))
+        }
     }
 
     // Exit with appropriate code
     if result.similar {
-        info!("Images are similar (similarity: {:.2}%)", result.similarity * 100.0);
+        info!(
+            "Images are similar (similarity: {:.2}%)",
+            result.similarity * 100.0
+        );
         std::process::exit(0);
     } else {
-        info!("Images are different (similarity: {:.2}%)", result.similarity * 100.0);
+        info!(
+            "Images are different (similarity: {:.2}%)",
+            result.similarity * 100.0
+        );
         std::process::exit(1);
     }
 }
@@ -626,15 +684,22 @@ fn parse_rgb_color(color_str: &str) -> Result<(u8, u8, u8)> {
     let parts: Vec<&str> = color_str.split(',').collect();
     if parts.len() != 3 {
         return Err(webshot::WebshotError::config(format!(
-            "Invalid color format: {}. Expected format: R,G,B (e.g., 255,0,0)", color_str
+            "Invalid color format: {}. Expected format: R,G,B (e.g., 255,0,0)",
+            color_str
         )));
     }
 
-    let r = parts[0].trim().parse::<u8>()
+    let r = parts[0]
+        .trim()
+        .parse::<u8>()
         .map_err(|_| webshot::WebshotError::config(format!("Invalid red value: {}", parts[0])))?;
-    let g = parts[1].trim().parse::<u8>()
+    let g = parts[1]
+        .trim()
+        .parse::<u8>()
         .map_err(|_| webshot::WebshotError::config(format!("Invalid green value: {}", parts[1])))?;
-    let b = parts[2].trim().parse::<u8>()
+    let b = parts[2]
+        .trim()
+        .parse::<u8>()
         .map_err(|_| webshot::WebshotError::config(format!("Invalid blue value: {}", parts[2])))?;
 
     Ok((r, g, b))
@@ -643,28 +708,36 @@ fn parse_rgb_color(color_str: &str) -> Result<(u8, u8, u8)> {
 /// Format comparison result as human-readable text
 fn format_comparison_result(result: &webshot::ComparisonResult) -> String {
     let mut output = String::new();
-    
-    output.push_str(&format!("Image Comparison Results\n"));
-    output.push_str(&format!("========================\n\n"));
-    
+
+    output.push_str("Image Comparison Results\n");
+    output.push_str("========================\n\n");
+
     output.push_str(&format!("Algorithm: {:?}\n", result.algorithm));
     output.push_str(&format!("Threshold: {:.2}\n", result.threshold));
-    output.push_str(&format!("Similarity: {:.4} ({:.2}%)\n", result.similarity, result.similarity * 100.0));
-    output.push_str(&format!("Similar: {}\n", if result.similar { "YES" } else { "NO" }));
-    
+    output.push_str(&format!(
+        "Similarity: {:.4} ({:.2}%)\n",
+        result.similarity,
+        result.similarity * 100.0
+    ));
+    output.push_str(&format!(
+        "Similar: {}\n",
+        if result.similar { "YES" } else { "NO" }
+    ));
+
     if let Some(diff_pixels) = result.different_pixels {
-        output.push_str(&format!("Different pixels: {}/{} ({:.2}%)\n", 
-            diff_pixels, 
+        output.push_str(&format!(
+            "Different pixels: {}/{} ({:.2}%)\n",
+            diff_pixels,
             result.total_pixels,
             (diff_pixels as f64 / result.total_pixels as f64) * 100.0
         ));
     }
-    
+
     output.push_str(&format!("Total pixels: {}\n", result.total_pixels));
-    
+
     if let Some(diff_path) = &result.diff_image_path {
         output.push_str(&format!("Difference image: {}\n", diff_path.display()));
     }
-    
+
     output
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -32,18 +32,13 @@ impl OutputHandler {
         let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
         let sanitized_domain = sanitize_filename(domain);
 
-        format!(
-            "{}_{}.{}",
-            sanitized_domain,
-            timestamp,
-            format.extension()
-        )
+        format!("{}_{}.{}", sanitized_domain, timestamp, format.extension())
     }
 
     /// Validate that the output path has a supported extension
     pub fn validate_output_path<P: AsRef<Path>>(path: P) -> Result<ImageFormat> {
         let path = path.as_ref();
-        
+
         let extension = path
             .extension()
             .and_then(|ext| ext.to_str())
@@ -72,8 +67,12 @@ impl OutputHandler {
 
         let img = match source_format {
             ImageFormat::Png => image::load_from_memory_with_format(data, image::ImageFormat::Png)?,
-            ImageFormat::Jpeg => image::load_from_memory_with_format(data, image::ImageFormat::Jpeg)?,
-            ImageFormat::WebP => image::load_from_memory_with_format(data, image::ImageFormat::WebP)?,
+            ImageFormat::Jpeg => {
+                image::load_from_memory_with_format(data, image::ImageFormat::Jpeg)?
+            }
+            ImageFormat::WebP => {
+                image::load_from_memory_with_format(data, image::ImageFormat::WebP)?
+            }
             ImageFormat::Pdf => {
                 return Err(WebshotError::config(
                     "Cannot convert from PDF format".to_string(),
@@ -90,7 +89,8 @@ impl OutputHandler {
             }
             ImageFormat::Jpeg => {
                 let quality = quality.unwrap_or(90);
-                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut output, quality);
+                let encoder =
+                    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut output, quality);
                 img.write_with_encoder(encoder)?;
             }
             ImageFormat::WebP => {
@@ -141,21 +141,22 @@ impl OutputHandler {
     pub fn get_file_size<P: AsRef<Path>>(path: P) -> Result<String> {
         let metadata = std::fs::metadata(path)?;
         let size = metadata.len();
-        
+
         Ok(format_file_size(size))
     }
 
     /// Create a temporary file with the given extension
     pub fn create_temp_file(extension: &str) -> Result<PathBuf> {
         use tempfile::NamedTempFile;
-        
-        let temp_file = NamedTempFile::with_suffix(&format!(".{}", extension))?;
+
+        let temp_file = NamedTempFile::with_suffix(format!(".{}", extension))?;
         let path = temp_file.path().to_path_buf();
-        
+
         // Keep the file but close the handle
-        temp_file.keep()
+        temp_file
+            .keep()
             .map_err(|e| WebshotError::config(format!("Failed to keep temp file: {}", e)))?;
-        
+
         Ok(path)
     }
 
@@ -196,14 +197,14 @@ impl OutputHandler {
     /// Check if file already exists and handle overwrites
     pub fn handle_existing_file<P: AsRef<Path>>(path: P, overwrite: bool) -> Result<()> {
         let path = path.as_ref();
-        
+
         if path.exists() && !overwrite {
             return Err(WebshotError::config(format!(
                 "File already exists: {}. Use --force to overwrite.",
                 path.display()
             )));
         }
-        
+
         Ok(())
     }
 }
@@ -264,7 +265,8 @@ mod tests {
 
     #[test]
     fn test_generate_filename() {
-        let filename = OutputHandler::generate_filename("https://example.com/path", ImageFormat::Png);
+        let filename =
+            OutputHandler::generate_filename("https://example.com/path", ImageFormat::Png);
         assert!(filename.starts_with("example.com_"));
         assert!(filename.ends_with(".png"));
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,7 +21,7 @@ async fn test_basic_screenshot() {
 
     cmd.assert().success();
     assert!(output_path.exists());
-    
+
     // Check that the file is not empty
     let metadata = fs::metadata(&output_path).unwrap();
     assert!(metadata.len() > 0);
@@ -33,17 +33,14 @@ async fn test_pdf_generation() {
     let output_path = temp_dir.path().join("test.pdf");
 
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("pdf")
-        .arg(TEST_URL)
-        .arg("-o")
-        .arg(&output_path);
+    cmd.arg("pdf").arg(TEST_URL).arg("-o").arg(&output_path);
 
     cmd.assert().success();
     assert!(output_path.exists());
-    
+
     // Check that the file is not empty and starts with PDF header
     let content = fs::read(&output_path).unwrap();
-    assert!(content.len() > 0);
+    assert!(!content.is_empty());
     assert!(content.starts_with(b"%PDF"));
 }
 
@@ -82,10 +79,7 @@ async fn test_javascript_execution() {
 #[tokio::test]
 async fn test_text_extraction() {
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("text")
-        .arg(TEST_URL)
-        .arg("-s")
-        .arg("h1");
+    cmd.arg("text").arg(TEST_URL).arg("-s").arg("h1");
 
     cmd.assert()
         .success()
@@ -95,7 +89,7 @@ async fn test_text_extraction() {
 #[tokio::test]
 async fn test_config_processing() {
     let temp_dir = TempDir::new().unwrap();
-    
+
     // Create a simple config file
     let config_content = format!(
         r#"
@@ -111,7 +105,7 @@ screenshots:
 "#,
         TEST_URL, TEST_URL
     );
-    
+
     let config_path = temp_dir.path().join("config.yaml");
     fs::write(&config_path, config_content).unwrap();
 
@@ -124,7 +118,7 @@ screenshots:
         .arg("2");
 
     cmd.assert().success();
-    
+
     assert!(temp_dir.path().join("test1.png").exists());
     assert!(temp_dir.path().join("test2.png").exists());
 }
@@ -143,7 +137,7 @@ async fn test_jpeg_quality() {
 
     cmd.assert().success();
     assert!(output_path.exists());
-    
+
     // Check that it's a JPEG file
     let content = fs::read(&output_path).unwrap();
     assert!(content.starts_with(&[0xFF, 0xD8, 0xFF])); // JPEG header
@@ -246,10 +240,7 @@ async fn test_verbose_logging() {
     let output_path = temp_dir.path().join("verbose.png");
 
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg(TEST_URL)
-        .arg("-o")
-        .arg(&output_path)
-        .arg("-v");
+    cmd.arg(TEST_URL).arg("-o").arg(&output_path).arg("-v");
 
     cmd.assert().success();
     assert!(output_path.exists());
@@ -279,14 +270,14 @@ async fn test_timeout_handling() {
 #[tokio::test]
 async fn test_config_validation() {
     let temp_dir = TempDir::new().unwrap();
-    
+
     // Create an invalid config file
     let config_content = r#"
 screenshots:
   - url: "not-a-valid-url"
     output: "test.png"
 "#;
-    
+
     let config_path = temp_dir.path().join("invalid-config.yaml");
     fs::write(&config_path, config_content).unwrap();
 
@@ -296,7 +287,7 @@ screenshots:
     cmd.assert().failure();
 }
 
-#[tokio::test] 
+#[tokio::test]
 async fn test_subcommand_screenshot() {
     let temp_dir = TempDir::new().unwrap();
     let output_path = temp_dir.path().join("subcommand.png");
@@ -325,7 +316,7 @@ async fn test_subcommand_pdf() {
 
     cmd.assert().success();
     assert!(output_path.exists());
-    
+
     let content = fs::read(&output_path).unwrap();
     assert!(content.starts_with(b"%PDF"));
 }
@@ -333,7 +324,7 @@ async fn test_subcommand_pdf() {
 #[tokio::test]
 async fn test_parallel_processing() {
     let temp_dir = TempDir::new().unwrap();
-    
+
     // Create config with multiple screenshots
     let config_content = format!(
         r#"
@@ -349,7 +340,7 @@ screenshots:
 "#,
         TEST_URL, TEST_URL, TEST_URL, TEST_URL
     );
-    
+
     let config_path = temp_dir.path().join("parallel-config.yaml");
     fs::write(&config_path, config_content).unwrap();
 
@@ -362,10 +353,10 @@ screenshots:
         .arg("4");
 
     cmd.assert().success();
-    
+
     // Check all files were created
     for i in 1..=4 {
-        assert!(temp_dir.path().join(&format!("parallel{}.png", i)).exists());
+        assert!(temp_dir.path().join(format!("parallel{}.png", i)).exists());
     }
 }
 
@@ -380,16 +371,14 @@ async fn test_compare_identical_images() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     // Create two identical images
     create_test_image(100, 100, [255, 0, 0], &img1_path);
     create_test_image(100, 100, [255, 0, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("compare")
-        .arg(&img1_path)
-        .arg(&img2_path);
-    
+    cmd.arg("compare").arg(&img1_path).arg(&img2_path);
+
     // Should exit with code 0 (similar images)
     cmd.assert().code(0);
 }
@@ -399,16 +388,14 @@ async fn test_compare_different_images() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     // Create two different images
     create_test_image(100, 100, [255, 0, 0], &img1_path); // Red
     create_test_image(100, 100, [0, 255, 0], &img2_path); // Green
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("compare")
-        .arg(&img1_path)
-        .arg(&img2_path);
-    
+    cmd.arg("compare").arg(&img1_path).arg(&img2_path);
+
     // Should exit with code 1 (different images)
     cmd.assert().code(1);
 }
@@ -419,11 +406,11 @@ async fn test_compare_with_diff_image() {
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
     let diff_path = temp_dir.path().join("diff.png");
-    
+
     // Create two different images
     create_test_image(100, 100, [255, 0, 0], &img1_path);
     create_test_image(100, 100, [0, 255, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
         .arg(&img1_path)
@@ -431,9 +418,9 @@ async fn test_compare_with_diff_image() {
         .arg("--diff-image")
         .arg("--diff-path")
         .arg(&diff_path);
-    
+
     cmd.assert().code(1);
-    
+
     // Check that diff image was created
     assert!(diff_path.exists());
     let metadata = fs::metadata(&diff_path).unwrap();
@@ -446,11 +433,11 @@ async fn test_compare_json_output() {
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
     let output_path = temp_dir.path().join("results.json");
-    
+
     // Create two different images
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [0, 255, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
         .arg(&img1_path)
@@ -459,13 +446,13 @@ async fn test_compare_json_output() {
         .arg("json")
         .arg("-o")
         .arg(&output_path);
-    
+
     cmd.assert().code(1);
-    
+
     // Check that JSON output was created
     assert!(output_path.exists());
     let content = fs::read_to_string(&output_path).unwrap();
-    
+
     // Parse and validate JSON structure
     let json: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(json["similar"].is_boolean());
@@ -480,14 +467,14 @@ async fn test_compare_different_algorithms() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     // Create slightly different images
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [250, 5, 5], &img2_path);
-    
+
     // Test different algorithms
     let algorithms = ["pixel-diff", "ssim", "mse", "psnr"];
-    
+
     for algorithm in &algorithms {
         let mut cmd = Command::cargo_bin("webshot").unwrap();
         cmd.arg("compare")
@@ -497,11 +484,11 @@ async fn test_compare_different_algorithms() {
             .arg(algorithm)
             .arg("--format")
             .arg("json");
-        
+
         let assertion = cmd.assert();
         let output = assertion.get_output();
         let stdout = String::from_utf8(output.stdout.clone()).unwrap();
-        
+
         if !stdout.is_empty() {
             let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
             // Algorithm names in JSON are PascalCase
@@ -522,11 +509,11 @@ async fn test_compare_with_threshold() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     // Create more different images for the strict test
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [200, 50, 50], &img2_path); // More different colors
-    
+
     // Test with strict threshold (should be different)
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
@@ -534,15 +521,15 @@ async fn test_compare_with_threshold() {
         .arg(&img2_path)
         .arg("-t")
         .arg("0.01"); // Very strict threshold, no anti-aliasing flag
-    
+
     cmd.assert().code(1); // Should be different with strict threshold
-    
+
     // Test with lenient threshold using more similar images
     let similar_img1_path = temp_dir.path().join("similar1.png");
     let similar_img2_path = temp_dir.path().join("similar2.png");
     create_test_image(50, 50, [255, 0, 0], &similar_img1_path);
     create_test_image(50, 50, [253, 2, 2], &similar_img2_path); // Very similar colors
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
         .arg(&similar_img1_path)
@@ -550,7 +537,7 @@ async fn test_compare_with_threshold() {
         .arg("-t")
         .arg("0.5") // Lenient threshold
         .arg("--ignore-antialiasing");
-    
+
     cmd.assert().code(0); // Should be similar with lenient threshold
 }
 
@@ -560,11 +547,11 @@ async fn test_compare_custom_diff_color() {
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
     let diff_path = temp_dir.path().join("diff.png");
-    
+
     // Create different images
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [0, 255, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
         .arg(&img1_path)
@@ -574,9 +561,9 @@ async fn test_compare_custom_diff_color() {
         .arg(&diff_path)
         .arg("--diff-color")
         .arg("0,0,255"); // Blue highlighting
-    
+
     cmd.assert().code(1);
-    
+
     // Check that diff image was created
     assert!(diff_path.exists());
 }
@@ -586,18 +573,17 @@ async fn test_compare_dimension_mismatch() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     // Create images with different dimensions
     create_test_image(100, 100, [255, 0, 0], &img1_path);
     create_test_image(200, 100, [255, 0, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("compare")
-        .arg(&img1_path)
-        .arg(&img2_path);
-    
+    cmd.arg("compare").arg(&img1_path).arg(&img2_path);
+
     // Should fail with error due to dimension mismatch
-    cmd.assert().failure()
+    cmd.assert()
+        .failure()
         .stderr(predicate::str::contains("dimensions don't match"));
 }
 
@@ -606,25 +592,23 @@ async fn test_compare_invalid_files() {
     let temp_dir = TempDir::new().unwrap();
     let nonexistent_path = temp_dir.path().join("nonexistent.png");
     let valid_path = temp_dir.path().join("valid.png");
-    
+
     create_test_image(50, 50, [255, 0, 0], &valid_path);
-    
+
     // Test with non-existent first image
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("compare")
-        .arg(&nonexistent_path)
-        .arg(&valid_path);
-    
-    cmd.assert().failure()
+    cmd.arg("compare").arg(&nonexistent_path).arg(&valid_path);
+
+    cmd.assert()
+        .failure()
         .stderr(predicate::str::contains("Failed to load first image"));
-    
+
     // Test with non-existent second image
     let mut cmd = Command::cargo_bin("webshot").unwrap();
-    cmd.arg("compare")
-        .arg(&valid_path)
-        .arg(&nonexistent_path);
-    
-    cmd.assert().failure()
+    cmd.arg("compare").arg(&valid_path).arg(&nonexistent_path);
+
+    cmd.assert()
+        .failure()
         .stderr(predicate::str::contains("Failed to load second image"));
 }
 
@@ -633,18 +617,19 @@ async fn test_compare_invalid_algorithm() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [0, 255, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
         .arg(&img1_path)
         .arg(&img2_path)
         .arg("-a")
         .arg("invalid-algorithm");
-    
-    cmd.assert().failure()
+
+    cmd.assert()
+        .failure()
         .stderr(predicate::str::contains("Unknown algorithm"));
 }
 
@@ -653,21 +638,21 @@ async fn test_compare_text_output_format() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    
+
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [0, 255, 0], &img2_path);
-    
+
     let mut cmd = Command::cargo_bin("webshot").unwrap();
     cmd.arg("compare")
         .arg(&img1_path)
         .arg(&img2_path)
         .arg("--format")
         .arg("text");
-    
-    cmd.assert().code(1)
+
+    cmd.assert()
+        .code(1)
         .stdout(predicate::str::contains("Image Comparison Results"))
         .stdout(predicate::str::contains("Algorithm:"))
         .stdout(predicate::str::contains("Similarity:"))
         .stdout(predicate::str::contains("Similar:"));
 }
-


### PR DESCRIPTION
## Summary
Restores the Rust formatting and Clippy quality baseline so Webshot can enforce clean local and CI gates again. The changes are focused on rustfmt output and small idiomatic Clippy fixes without changing CLI behavior.

## Changes
- Applies rustfmt formatting across the Rust sources and integration tests.
- Replaces a few Clippy-reported patterns with idiomatic equivalents.
- Keeps existing large CLI helper signatures working while acknowledging them for the current baseline.

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
