### PR TITLE
fix: clarify browser failure guidance

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -70,7 +70,7 @@ impl Browser {
         };
 
         let browser = ChromeBrowser::new(launch_options)
-            .map_err(|e| WebshotError::BrowserLaunch(e.to_string()))?;
+            .map_err(|e| WebshotError::browser_launch(e.to_string()))?;
 
         debug!("Browser launched successfully");
 
@@ -97,11 +97,11 @@ impl Browser {
 
         info!("Navigating to: {}", url);
         tab.navigate_to(url)
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
 
         // Wait for page load
         tab.wait_until_navigated()
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
 
         // Execute custom JavaScript if provided
         if let Some(script) = &options.javascript {
@@ -173,9 +173,9 @@ impl Browser {
 
         info!("Navigating to: {}", url);
         tab.navigate_to(url)
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
         tab.wait_until_navigated()
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
 
         // Execute custom JavaScript if provided
         if let Some(script) = &javascript {
@@ -249,9 +249,9 @@ impl Browser {
 
         info!("Navigating to: {}", url);
         tab.navigate_to(url)
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
         tab.wait_until_navigated()
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
 
         // Execute custom JavaScript if provided
         if let Some(script) = &javascript {
@@ -272,11 +272,9 @@ impl Browser {
 
         let text = if let Some(selector_str) = selector {
             info!("Extracting text from element: {}", selector_str);
-            let element =
-                tab.find_element(&selector_str)
-                    .map_err(|_e| WebshotError::ElementNotFound {
-                        selector: selector_str,
-                    })?;
+            let element = tab
+                .find_element(&selector_str)
+                .map_err(|_e| WebshotError::element_not_found(selector_str))?;
             element.get_inner_text().map_err(WebshotError::Browser)?
         } else {
             info!("Extracting text from entire page");
@@ -395,11 +393,9 @@ impl Browser {
     ) -> Result<()> {
         let screenshot_data = if let Some(selector) = &options.selector {
             info!("Taking element screenshot: {}", selector);
-            let element =
-                tab.find_element(selector)
-                    .map_err(|_e| WebshotError::ElementNotFound {
-                        selector: selector.clone(),
-                    })?;
+            let element = tab
+                .find_element(selector)
+                .map_err(|_e| WebshotError::element_not_found(selector.clone()))?;
             element
                 .capture_screenshot(Page::CaptureScreenshotFormatOption::Png)
                 .map_err(|e| WebshotError::screenshot(e.to_string()))?
@@ -521,9 +517,9 @@ impl Browser {
 
         // Navigate and process
         tab.navigate_to(&config.url)
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
         tab.wait_until_navigated()
-            .map_err(|e| WebshotError::Navigation(e.to_string()))?;
+            .map_err(|e| WebshotError::navigation(e.to_string()))?;
 
         // Execute JavaScript
         if let Some(script) = &config.javascript {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,19 +7,19 @@ pub enum WebshotError {
     #[error("Browser error: {0}")]
     Browser(#[from] anyhow::Error),
 
-    #[error("Browser launch error: {0}")]
+    #[error("Browser launch failed: {0}. Verify that Chrome or Chromium is installed and reachable, or pass --chrome-path with the executable path. In containers, also try --chrome-flag=--no-sandbox and confirm the process can write to its temporary directory.")]
     BrowserLaunch(String),
 
     #[error("Tab error: {0}")]
     Tab(String),
 
-    #[error("Navigation error: {0}")]
+    #[error("Navigation failed: {0}. Check that the URL includes a supported scheme such as https://, the page is reachable from this machine, and the timeout is long enough for the page to load.")]
     Navigation(String),
 
     #[error("Screenshot error: {0}")]
     Screenshot(String),
 
-    #[error("Element not found: {selector}")]
+    #[error("Element not found for selector '{selector}'. Check that the selector is correct, the element is present after page load, or use --wait-for/--timeout when content appears asynchronously.")]
     ElementNotFound { selector: String },
 
     #[error("JavaScript execution error: {0}")]
@@ -71,6 +71,11 @@ impl WebshotError {
         Self::Navigation(msg.into())
     }
 
+    /// Create a browser launch error
+    pub fn browser_launch(msg: impl Into<String>) -> Self {
+        Self::BrowserLaunch(msg.into())
+    }
+
     /// Create a screenshot error
     pub fn screenshot(msg: impl Into<String>) -> Self {
         Self::Screenshot(msg.into())
@@ -96,5 +101,49 @@ impl WebshotError {
         Self::Timeout {
             condition: condition.into(),
         }
+    }
+
+    /// Create an element-not-found error.
+    pub fn element_not_found(selector: impl Into<String>) -> Self {
+        Self::ElementNotFound {
+            selector: selector.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_launch_error_includes_chrome_path_guidance() {
+        let error = WebshotError::browser_launch("No such file or directory");
+        let message = error.to_string();
+
+        assert!(message.contains("Browser launch failed"));
+        assert!(message.contains("No such file or directory"));
+        assert!(message.contains("--chrome-path"));
+        assert!(message.contains("Chrome or Chromium"));
+    }
+
+    #[test]
+    fn navigation_error_includes_url_and_timeout_guidance() {
+        let error = WebshotError::navigation("net::ERR_NAME_NOT_RESOLVED");
+        let message = error.to_string();
+
+        assert!(message.contains("Navigation failed"));
+        assert!(message.contains("net::ERR_NAME_NOT_RESOLVED"));
+        assert!(message.contains("https://"));
+        assert!(message.contains("timeout"));
+    }
+
+    #[test]
+    fn missing_element_error_includes_selector_and_wait_guidance() {
+        let error = WebshotError::element_not_found(".loaded-later");
+        let message = error.to_string();
+
+        assert!(message.contains(".loaded-later"));
+        assert!(message.contains("--wait-for"));
+        assert!(message.contains("--timeout"));
     }
 }


### PR DESCRIPTION
## Summary
Improves Webshot's failure messages for browser startup, page navigation, and missing selector cases. The messages now keep the original failure detail while adding concrete remediation hints for Chrome paths, URL reachability, timeouts, and asynchronous content.

## Changes
- Adds helper constructors for browser launch and selector-not-found errors.
- Preserves the existing public `WebshotError` variant shapes while enriching their display output.
- Updates browser call sites to use the clearer constructor helpers.
- Adds regression tests for the new operator guidance in error messages.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
