### PR TITLE
docs: verify CLI height flag examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You'll need Chrome or Chromium installed. The tool will find it automatically.
 webshot https://example.com
 
 # Custom size and output
-webshot https://example.com -o screenshot.png -w 1920 -h 1080
+webshot https://example.com -o screenshot.png -w 1920 -H 1080
 
 # Screenshot just the header
 webshot https://github.com -s ".Header" -o header.png
@@ -58,7 +58,7 @@ webshot text https://example.com
 
 - `-o, --output` - Output file path
 - `-w, --width` - Viewport width (default: 1280)
-- `-h, --height` - Viewport height (default: 800)
+- `-H, --height` - Viewport height (default: 800)
 - `-s, --selector` - CSS selector for element screenshots
 - `-j, --javascript` - JavaScript to run before screenshot
 - `--wait-for` - Wait for element to appear
@@ -66,13 +66,14 @@ webshot text https://example.com
 - `--retina` - Enable high-DPI mode
 - `-q, --quality` - JPEG/WebP quality 1-100
 - `-v, --verbose` - Verbose logging
+- `-h, --help` - Show help (`-H` is used for viewport height)
 
 ### Subcommands
 
 #### `screenshot`
 Basic screenshot with full options:
 ```bash
-webshot screenshot https://example.com -o test.png -w 1920 -h 1080
+webshot screenshot https://example.com -o test.png -w 1920 -H 1080
 ```
 
 #### `pdf`
@@ -174,10 +175,10 @@ screenshots:
 ### Mobile Screenshots
 ```bash
 # iPhone viewport
-webshot https://example.com -w 390 -h 844 -o mobile.png
+webshot https://example.com -w 390 -H 844 -o mobile.png
 
 # iPad viewport  
-webshot https://example.com -w 820 -h 1180 -o tablet.png
+webshot https://example.com -w 820 -H 1180 -o tablet.png
 ```
 
 ### JavaScript Execution

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
-use std::fs;
+use std::{fs, path::Path};
 use tempfile::TempDir;
 
 const TEST_URL: &str = "https://httpbin.org/html";
@@ -233,7 +233,43 @@ async fn test_help_output() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("webshot"))
-        .stdout(predicate::str::contains("screenshot"));
+        .stdout(predicate::str::contains("screenshot"))
+        .stdout(predicate::str::contains("-H, --height"))
+        .stdout(predicate::str::contains("-h, --help"));
+}
+
+#[tokio::test]
+async fn test_screenshot_help_height_short_flag() {
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.args(["screenshot", "--help"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("-H, --height"))
+        .stdout(predicate::str::contains("-h, --help"));
+}
+
+#[test]
+fn test_readme_uses_actual_height_short_flag() {
+    let readme_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md");
+    let readme = fs::read_to_string(readme_path).unwrap();
+
+    assert!(
+        !readme.contains("-h, --height"),
+        "README should document -H for --height because -h is clap help"
+    );
+    assert!(
+        readme.contains("-H, --height"),
+        "README should document the actual short flag for --height"
+    );
+    assert!(
+        readme.contains("webshot https://example.com -o screenshot.png -w 1920 -H 1080"),
+        "README quick-start example should use -H for viewport height"
+    );
+    assert!(
+        readme.contains("webshot screenshot https://example.com -o test.png -w 1920 -H 1080"),
+        "README screenshot subcommand example should use -H for viewport height"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Corrects the README's viewport-height examples to use the actual `-H, --height` short flag and clarifies that lowercase `-h` is reserved for help. Adds deterministic regression coverage so the documented flag stays aligned with the CLI help output.

## Changes
- Updates screenshot and mobile README examples from `-h` to `-H` for viewport height.
- Documents `-h, --help` alongside the height flag distinction.
- Adds integration tests for root and screenshot help output plus README height-flag examples.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
