### PR TITLE
fix: restrict navigation URL schemes

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, ScreenshotConfig};
+use crate::config::{validate_navigation_url, Config, ScreenshotConfig};
 use crate::error::{Result, WebshotError};
 use crate::screenshot::{ImageFormat, ScreenshotOptions};
 use headless_chrome::protocol::cdp::Page;
@@ -87,6 +87,7 @@ impl Browser {
         output_path: P,
         options: &ScreenshotOptions,
     ) -> Result<()> {
+        validate_navigation_url(url, "screenshot API")?;
         options.validate()?;
 
         let tab = self
@@ -160,6 +161,7 @@ impl Browser {
         timeout: u64,
         user_agent: Option<String>,
     ) -> Result<()> {
+        validate_navigation_url(url, "pdf API")?;
         let tab = self
             .browser
             .new_tab()
@@ -236,6 +238,7 @@ impl Browser {
         timeout: u64,
         user_agent: Option<String>,
     ) -> Result<String> {
+        validate_navigation_url(url, "text API")?;
         let tab = self
             .browser
             .new_tab()
@@ -442,6 +445,7 @@ impl Browser {
         config: ScreenshotConfig,
         output_dir: Option<PathBuf>,
     ) -> Result<()> {
+        validate_navigation_url(&config.url, "batch screenshot API")?;
         let tab = self
             .browser
             .new_tab()

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,26 @@ use crate::error::{Result, WebshotError};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+/// Validate that a navigation target is a syntactically valid HTTP(S) URL.
+///
+/// This is a scheme allowlist, not a full network safety check. CLI callers
+/// intentionally validate before browser startup while browser APIs validate
+/// again at the navigation boundary for defense in depth.
+pub fn validate_navigation_url(url: &str, context: impl AsRef<str>) -> Result<()> {
+    let parsed_url = url::Url::parse(url).map_err(|error| {
+        WebshotError::config(format!("Invalid URL in {}: {}", context.as_ref(), error))
+    })?;
+
+    match parsed_url.scheme() {
+        "http" | "https" => Ok(()),
+        scheme => Err(WebshotError::config(format!(
+            "Unsupported URL scheme in {}: {}. Supported schemes: http, https",
+            context.as_ref(),
+            scheme
+        ))),
+    }
+}
+
 /// Batch processing configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
@@ -217,10 +237,7 @@ impl Config {
         }
 
         for (i, screenshot) in self.screenshots.iter().enumerate() {
-            // Validate URL
-            url::Url::parse(&screenshot.url).map_err(|e| {
-                WebshotError::config(format!("Invalid URL in screenshot {}: {}", i, e))
-            })?;
+            validate_navigation_url(&screenshot.url, format!("screenshot {}", i))?;
 
             // Validate viewport dimensions
             if screenshot.width == 0 || screenshot.height == 0 {
@@ -363,6 +380,42 @@ mod tests {
         config.screenshots[0].url = "https://example.com".to_string();
         config.screenshots[0].width = 0;
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_validation_rejects_non_web_url_schemes() {
+        for url in [
+            "file:///etc/passwd",
+            "data:text/html,<h1>Test</h1>",
+            "javascript:alert(1)",
+            "chrome://settings",
+            "ftp://example.com/file.png",
+        ] {
+            let mut screenshot = valid_screenshot_config();
+            screenshot.url = url.to_string();
+
+            let config = Config {
+                screenshots: vec![screenshot],
+                defaults: DefaultConfig::default(),
+            };
+
+            let error = config.validate().unwrap_err();
+
+            assert!(error.to_string().contains("Unsupported URL scheme"));
+        }
+    }
+
+    #[test]
+    fn test_config_validation_accepts_case_insensitive_web_url_schemes() {
+        let mut screenshot = valid_screenshot_config();
+        screenshot.url = "HTTPS://example.com".to_string();
+
+        let config = Config {
+            screenshots: vec![screenshot],
+            defaults: DefaultConfig::default(),
+        };
+
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use webshot::{Browser, ComparisonOptions, Config, ImageComparator, Result, ScreenshotOptions};
+use webshot::{
+    config::validate_navigation_url, Browser, ComparisonOptions, Config, ImageComparator, Result,
+    ScreenshotOptions,
+};
 
 #[derive(Parser)]
 #[command(
@@ -16,7 +19,7 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// URL to screenshot (if no subcommand provided)
+    /// HTTP(S) URL to screenshot (if no subcommand provided)
     #[arg(value_name = "URL")]
     url: Option<String>,
 
@@ -86,7 +89,7 @@ enum Commands {
     /// Take a single screenshot
     #[command(alias = "shot")]
     Screenshot {
-        /// URL to screenshot
+        /// HTTP(S) URL to screenshot
         url: String,
         /// Output file path
         #[arg(short, long)]
@@ -121,7 +124,7 @@ enum Commands {
     },
     /// Generate PDF from webpage
     Pdf {
-        /// URL to convert to PDF
+        /// HTTP(S) URL to convert to PDF
         url: String,
         /// Output PDF file path
         #[arg(short, long)]
@@ -161,7 +164,7 @@ enum Commands {
     },
     /// Extract text content from webpage
     Text {
-        /// URL to extract text from
+        /// HTTP(S) URL to extract text from
         url: String,
         /// CSS selector for specific element
         #[arg(short, long)]
@@ -416,6 +419,7 @@ async fn take_screenshot(
     no_javascript: bool,
     user_agent: Option<String>,
 ) -> Result<()> {
+    validate_navigation_url(url, "screenshot command")?;
     info!("Taking screenshot of: {}", url);
 
     let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;
@@ -479,6 +483,7 @@ async fn generate_pdf(
     no_javascript: bool,
     user_agent: Option<String>,
 ) -> Result<()> {
+    validate_navigation_url(url, "pdf command")?;
     info!("Generating PDF of: {}", url);
 
     let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;
@@ -543,6 +548,7 @@ async fn extract_text(
     no_javascript: bool,
     user_agent: Option<String>,
 ) -> Result<()> {
+    validate_navigation_url(url, "text command")?;
     info!("Extracting text from: {}", url);
 
     let browser = Browser::new(chrome_path, chrome_flags, !no_javascript).await?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -249,6 +249,22 @@ async fn test_screenshot_help_height_short_flag() {
         .stdout(predicate::str::contains("-h, --help"));
 }
 
+#[tokio::test]
+async fn test_cli_rejects_non_web_url_before_browser_startup() {
+    for args in [
+        vec!["screenshot", "file:///etc/passwd"],
+        vec!["pdf", "file:///etc/passwd"],
+        vec!["text", "data:text/html,<h1>Test</h1>"],
+    ] {
+        let mut cmd = Command::cargo_bin("webshot").unwrap();
+        cmd.args(args);
+
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("Unsupported URL scheme"));
+    }
+}
+
 #[test]
 fn test_readme_uses_actual_height_short_flag() {
     let readme_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md");


### PR DESCRIPTION
## Summary
Restricts Webshot navigation targets to HTTP and HTTPS URLs so unsupported schemes are rejected before Chrome navigation. The validation is applied at CLI entry points and again at browser API boundaries to keep direct library usage and batch processing guarded.

## Changes
- Adds shared navigation URL scheme validation for HTTP(S)-only targets.
- Applies validation to screenshot, PDF, text extraction, and batch screenshot paths.
- Updates CLI help text to describe URL arguments as HTTP(S) targets.
- Adds regression coverage for unsupported schemes and case-insensitive web URL schemes.

## Test Plan
- Rust formatting passed.
- Clippy passed with all targets and features.
- Full test suite passed with all features.
- Independent review found no blocking findings.
