### PR TITLE
fix: create output parent directories

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,5 +1,6 @@
 use crate::config::{validate_navigation_url, Config, ScreenshotConfig};
 use crate::error::{Result, WebshotError};
+use crate::output::OutputHandler;
 use crate::screenshot::{ImageFormat, ScreenshotOptions};
 use headless_chrome::protocol::cdp::Page;
 use headless_chrome::types::PrintToPdfOptions;
@@ -222,6 +223,7 @@ impl Browser {
         let pdf_data = tab
             .print_to_pdf(Some(pdf_options))
             .map_err(|e| WebshotError::pdf(e.to_string()))?;
+        OutputHandler::ensure_output_dir(&output_path)?;
         std::fs::write(&output_path, pdf_data)?;
 
         info!("PDF saved to: {}", output_path.as_ref().display());
@@ -408,6 +410,8 @@ impl Browser {
                 .map_err(|e| WebshotError::screenshot(e.to_string()))?
         };
 
+        OutputHandler::ensure_output_dir(&output_path)?;
+
         match format {
             ImageFormat::Png => {
                 std::fs::write(&output_path, screenshot_data)?;
@@ -458,10 +462,7 @@ impl Browser {
             config.output.clone()
         };
 
-        // Create parent directories if they don't exist
-        if let Some(parent) = output_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        OutputHandler::ensure_output_dir(&output_path)?;
 
         let options = ScreenshotOptions {
             width: config.width,

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,4 +1,5 @@
 use crate::error::{Result, WebshotError};
+use crate::output::OutputHandler;
 use image::{DynamicImage, ImageBuffer, Rgb, RgbImage};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -366,6 +367,8 @@ impl ImageComparator {
             }
         }
 
+        OutputHandler::ensure_output_dir(&output_path)?;
+
         diff_img
             .save(&output_path)
             .map_err(|e| WebshotError::config(format!("Failed to save diff image: {}", e)))?;
@@ -484,7 +487,7 @@ mod tests {
     #[test]
     fn test_diff_image_generation() {
         let temp_dir = TempDir::new().unwrap();
-        let diff_path = temp_dir.path().join("diff.png");
+        let diff_path = temp_dir.path().join("nested").join("diff.png");
 
         let img1 = create_test_image(10, 10, [255, 0, 0]);
         let img2 = create_test_image(10, 10, [0, 255, 0]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use webshot::{
-    config::validate_navigation_url, Browser, ComparisonOptions, Config, ImageComparator, Result,
-    ScreenshotOptions,
+    config::validate_navigation_url, output::OutputHandler, Browser, ComparisonOptions, Config,
+    ImageComparator, Result, ScreenshotOptions,
 };
 
 #[derive(Parser)]
@@ -559,6 +559,7 @@ async fn extract_text(
 
     match output {
         Some(path) => {
+            OutputHandler::ensure_output_dir(&path)?;
             std::fs::write(&path, &text)?;
             println!("Text saved to: {}", path.display());
         }
@@ -645,6 +646,7 @@ async fn compare_images(
             })?;
 
             if let Some(output_path) = output {
+                OutputHandler::ensure_output_dir(&output_path)?;
                 std::fs::write(output_path, json)?;
                 info!("Comparison results saved to JSON file");
             } else {
@@ -655,6 +657,7 @@ async fn compare_images(
             let text_output = format_comparison_result(&result);
 
             if let Some(output_path) = output {
+                OutputHandler::ensure_output_dir(&output_path)?;
                 std::fs::write(output_path, text_output)?;
                 info!("Comparison results saved to text file");
             } else {

--- a/src/output.rs
+++ b/src/output.rs
@@ -310,6 +310,12 @@ mod tests {
         assert!(!test_path.parent().unwrap().exists());
         OutputHandler::ensure_output_dir(&test_path).unwrap();
         assert!(test_path.parent().unwrap().exists());
+        assert!(!test_path.exists());
+    }
+
+    #[test]
+    fn test_ensure_output_dir_allows_current_directory_output() {
+        OutputHandler::ensure_output_dir("screenshot.png").unwrap();
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -657,7 +657,7 @@ async fn test_compare_json_output() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    let output_path = temp_dir.path().join("results.json");
+    let output_path = temp_dir.path().join("reports").join("results.json");
 
     // Create two different images
     create_test_image(50, 50, [255, 0, 0], &img1_path);
@@ -859,7 +859,7 @@ async fn test_compare_invalid_algorithm() {
 }
 
 #[tokio::test]
-async fn test_compare_text_output_format() {
+async fn test_compare_text_stdout_output_format() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
@@ -880,4 +880,32 @@ async fn test_compare_text_output_format() {
         .stdout(predicate::str::contains("Algorithm:"))
         .stdout(predicate::str::contains("Similarity:"))
         .stdout(predicate::str::contains("Similar:"));
+}
+
+#[tokio::test]
+async fn test_compare_text_output_format() {
+    let temp_dir = TempDir::new().unwrap();
+    let img1_path = temp_dir.path().join("img1.png");
+    let img2_path = temp_dir.path().join("img2.png");
+    let output_path = temp_dir.path().join("reports").join("results.txt");
+
+    create_test_image(50, 50, [255, 0, 0], &img1_path);
+    create_test_image(50, 50, [0, 255, 0], &img2_path);
+
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.arg("compare")
+        .arg(&img1_path)
+        .arg(&img2_path)
+        .arg("--format")
+        .arg("text")
+        .arg("-o")
+        .arg(&output_path);
+
+    cmd.assert().code(1);
+
+    let text_output = fs::read_to_string(&output_path).unwrap();
+    assert!(text_output.contains("Image Comparison Results"));
+    assert!(text_output.contains("Algorithm:"));
+    assert!(text_output.contains("Similarity:"));
+    assert!(text_output.contains("Similar:"));
 }


### PR DESCRIPTION
## Summary
Generated Webshot outputs now create missing parent directories before writing files. This makes nested output paths work consistently for screenshots, PDFs, text extraction, comparison reports, and diff images.

## Changes
- Create parent directories before writing browser image/PDF outputs, text extraction files, comparison reports, and diff images.
- Reuse the existing output helper instead of duplicating directory creation logic.
- Add regression coverage for nested comparison outputs, nested diff images, and current-directory output paths.
- Preserve stdout coverage for text comparison output when no output file is provided.

## Test Plan
- Rust formatting passed.
- Rust Clippy passed with all targets and all features.
- Rust tests passed with all features.
- Debug build passed with all features.