### PR TITLE
docs: clarify output path behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ screenshots:
 
 ### Configuration Options
 
-- `url` - Target URL (required)
+- `url` - Target HTTP(S) URL (required)
 - `output` - Output file path (required)
 - `width`, `height` - Viewport dimensions
 - `selector` - CSS selector for element screenshots
@@ -169,6 +169,15 @@ screenshots:
 - `headers` - Custom HTTP headers
 - `cookies` - Cookies to set
 - `auth` - Basic authentication (username/password)
+
+#### Output Behavior
+
+- Supported output extensions are `.png`, `.jpg`, `.jpeg`, `.webp`, and `.pdf`.
+- Webshot chooses the runtime output format from the `output` filename extension.
+- Relative screenshot `output` paths are resolved under `defaults.output_dir` when it is set.
+- The `multi` command's `-o, --output-dir` option is prepended at runtime to each loaded output path, including any `defaults.output_dir` component already applied during config loading. For example, `defaults.output_dir: "screenshots"`, `output: "home.png"`, and `webshot multi config.yaml -o artifacts` writes `artifacts/screenshots/home.png`.
+- Parent directories for screenshot, PDF, text, diff-image, and JSON comparison outputs are created automatically.
+- Existing output files are replaced when a command writes the same path.
 
 ## Examples
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -289,6 +289,29 @@ fn test_readme_uses_actual_height_short_flag() {
 }
 
 #[test]
+fn test_readme_documents_batch_output_behavior() {
+    let readme_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md");
+    let readme = fs::read_to_string(readme_path).unwrap();
+
+    for detail in [
+        "#### Output Behavior",
+        "Target HTTP(S) URL (required)",
+        "Supported output extensions are `.png`, `.jpg`, `.jpeg`, `.webp`, and `.pdf`.",
+        "Webshot chooses the runtime output format from the `output` filename extension.",
+        "Relative screenshot `output` paths are resolved under `defaults.output_dir` when it is set.",
+        "The `multi` command's `-o, --output-dir` option is prepended at runtime to each loaded output path",
+        "artifacts/screenshots/home.png",
+        "Parent directories for screenshot, PDF, text, diff-image, and JSON comparison outputs are created automatically.",
+        "Existing output files are replaced when a command writes the same path.",
+    ] {
+        assert!(
+            readme.contains(detail),
+            "README should document batch/output behavior detail: {detail}"
+        );
+    }
+}
+
+#[test]
 fn test_readme_release_flow_matches_github_actions() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let readme = fs::read_to_string(manifest_dir.join("README.md"))


### PR DESCRIPTION
## Summary
Clarifies Webshot's documented output behavior for batch and single-command workflows. The README now explains supported output extensions, filename-extension based format selection, output directory composition, automatic parent-directory creation, and existing-file replacement behavior.

## Changes
- Add an Output Behavior section to the README with current output-path semantics.
- Document how `defaults.output_dir` and `webshot multi -o` compose.
- Add a README regression test so the output behavior documentation remains present.

## Test Plan
- Rust formatting check passed.
- Clippy passed with all targets and features.
- Full Rust test suite passed with all features.
