### PR TITLE
test: cover output directory and overwrite behavior

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -10,6 +10,13 @@ impl OutputHandler {
     /// Ensure the output directory exists
     pub fn ensure_output_dir<P: AsRef<Path>>(path: P) -> Result<()> {
         if let Some(parent) = path.as_ref().parent() {
+            if parent.exists() && !parent.is_dir() {
+                return Err(WebshotError::config(format!(
+                    "Output parent path is not a directory: {}",
+                    parent.display()
+                )));
+            }
+
             if !parent.exists() {
                 info!("Creating output directory: {}", parent.display());
                 std::fs::create_dir_all(parent)?;
@@ -314,8 +321,74 @@ mod tests {
     }
 
     #[test]
+    fn test_ensure_output_dir_creates_nested_parent_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir
+            .path()
+            .join("level-one")
+            .join("level-two")
+            .join("level-three")
+            .join("screenshot.png");
+
+        OutputHandler::ensure_output_dir(&output_path).unwrap();
+
+        assert!(output_path.parent().unwrap().is_dir());
+        assert!(!output_path.exists());
+    }
+
+    #[test]
+    fn test_ensure_output_dir_keeps_existing_file_untouched() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("existing").join("screenshot.png");
+        std::fs::create_dir(output_path.parent().unwrap()).unwrap();
+        std::fs::write(&output_path, b"original").unwrap();
+
+        OutputHandler::ensure_output_dir(&output_path).unwrap();
+
+        assert_eq!(std::fs::read(&output_path).unwrap(), b"original");
+    }
+
+    #[test]
+    fn test_ensure_output_dir_errors_when_parent_component_is_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_parent = temp_dir.path().join("not-a-directory");
+        let output_path = file_parent.join("screenshot.png");
+        std::fs::write(&file_parent, b"not a directory").unwrap();
+
+        assert!(OutputHandler::ensure_output_dir(&output_path).is_err());
+    }
+
+    #[test]
     fn test_ensure_output_dir_allows_current_directory_output() {
         OutputHandler::ensure_output_dir("screenshot.png").unwrap();
+    }
+
+    #[test]
+    fn test_handle_existing_file_allows_missing_file_without_overwrite() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("missing.png");
+
+        OutputHandler::handle_existing_file(&output_path, false).unwrap();
+    }
+
+    #[test]
+    fn test_handle_existing_file_rejects_existing_file_without_overwrite() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("existing.png");
+        std::fs::write(&output_path, b"existing").unwrap();
+
+        let error = OutputHandler::handle_existing_file(&output_path, false).unwrap_err();
+
+        assert!(error.to_string().contains("Use --force to overwrite"));
+    }
+
+    #[test]
+    fn test_handle_existing_file_allows_existing_file_with_overwrite() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("existing.png");
+        std::fs::write(&output_path, b"existing").unwrap();
+
+        OutputHandler::handle_existing_file(&output_path, true).unwrap();
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -676,13 +676,16 @@ async fn test_compare_with_diff_image() {
 }
 
 #[tokio::test]
-async fn test_compare_json_output() {
+async fn test_compare_json_output_creates_parent_dirs_and_overwrites() {
     let temp_dir = TempDir::new().unwrap();
     let img1_path = temp_dir.path().join("img1.png");
     let img2_path = temp_dir.path().join("img2.png");
-    let output_path = temp_dir.path().join("reports").join("results.json");
+    let output_path = temp_dir
+        .path()
+        .join("reports")
+        .join("nested")
+        .join("results.json");
 
-    // Create two different images
     create_test_image(50, 50, [255, 0, 0], &img1_path);
     create_test_image(50, 50, [0, 255, 0], &img2_path);
 
@@ -696,18 +699,120 @@ async fn test_compare_json_output() {
         .arg(&output_path);
 
     cmd.assert().code(1);
+    assert_json_comparison_output(&output_path);
 
-    // Check that JSON output was created
-    assert!(output_path.exists());
+    fs::write(&output_path, "stale output").unwrap();
+
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.arg("compare")
+        .arg(&img1_path)
+        .arg(&img2_path)
+        .arg("--format")
+        .arg("json")
+        .arg("-o")
+        .arg(&output_path);
+
+    cmd.assert().code(1);
     let content = fs::read_to_string(&output_path).unwrap();
+    assert!(!content.contains("stale output"));
+    assert_json_comparison_output(&output_path);
+}
 
-    // Parse and validate JSON structure
+fn assert_json_comparison_output(output_path: &Path) {
+    assert!(output_path.exists());
+    let content = fs::read_to_string(output_path).unwrap();
     let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+
     assert!(json["similar"].is_boolean());
     assert!(json["similarity"].is_number());
     assert!(json["algorithm"].is_string());
     assert!(json["threshold"].is_number());
     assert!(json["total_pixels"].is_number());
+}
+
+#[tokio::test]
+async fn test_compare_text_output_creates_parent_dirs_and_overwrites() {
+    let temp_dir = TempDir::new().unwrap();
+    let img1_path = temp_dir.path().join("img1.png");
+    let img2_path = temp_dir.path().join("img2.png");
+    let output_path = temp_dir
+        .path()
+        .join("reports")
+        .join("nested")
+        .join("results.txt");
+
+    create_test_image(50, 50, [255, 0, 0], &img1_path);
+    create_test_image(50, 50, [255, 0, 0], &img2_path);
+
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.arg("compare")
+        .arg(&img1_path)
+        .arg(&img2_path)
+        .arg("-o")
+        .arg(&output_path);
+
+    cmd.assert().code(0);
+    assert!(output_path.exists());
+    assert!(fs::read_to_string(&output_path)
+        .unwrap()
+        .contains("Similar: YES"));
+
+    fs::write(&output_path, "stale output").unwrap();
+
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.arg("compare")
+        .arg(&img1_path)
+        .arg(&img2_path)
+        .arg("-o")
+        .arg(&output_path);
+
+    cmd.assert().code(0);
+    let content = fs::read_to_string(&output_path).unwrap();
+    assert!(content.contains("Image Comparison Results"));
+    assert!(!content.contains("stale output"));
+}
+
+#[tokio::test]
+async fn test_compare_diff_image_creates_parent_dirs_and_overwrites() {
+    let temp_dir = TempDir::new().unwrap();
+    let img1_path = temp_dir.path().join("img1.png");
+    let img2_path = temp_dir.path().join("img2.png");
+    let diff_path = temp_dir
+        .path()
+        .join("diffs")
+        .join("nested")
+        .join("diff.png");
+
+    create_test_image(50, 50, [255, 0, 0], &img1_path);
+    create_test_image(50, 50, [0, 255, 0], &img2_path);
+
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.arg("compare")
+        .arg(&img1_path)
+        .arg(&img2_path)
+        .arg("--diff-image")
+        .arg("--diff-path")
+        .arg(&diff_path);
+
+    cmd.assert().code(1);
+    assert!(diff_path.exists());
+    assert!(image::open(&diff_path).is_ok());
+
+    fs::write(&diff_path, "stale output").unwrap();
+
+    let mut cmd = Command::cargo_bin("webshot").unwrap();
+    cmd.arg("compare")
+        .arg(&img1_path)
+        .arg(&img2_path)
+        .arg("--diff-image")
+        .arg("--diff-path")
+        .arg(&diff_path);
+
+    cmd.assert().code(1);
+    let diff_image = image::open(&diff_path).unwrap();
+    assert_eq!(diff_image.width(), 50);
+    assert_eq!(diff_image.height(), 50);
+    assert_ne!(fs::read(&diff_path).unwrap(), b"stale output");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Strengthens Webshot's output-path behavior around parent-directory creation and existing output files. The change adds deterministic regression coverage for helper-level output handling and compare-command outputs, and it now reports a clear configuration error when an output parent path is already a regular file.

## Changes
- Add output helper tests for nested parent creation, existing file preservation, file-as-parent rejection, and overwrite policy handling.
- Add compare-command regression tests for JSON, text, and diff-image outputs writing to nested paths and replacing stale output files.
- Reject output paths whose parent component already exists as a non-directory.

## Test Plan
- Rust formatting passed.
- Rust linting passed with warnings denied.
- Full Rust test suite passed, including deterministic integration tests.
